### PR TITLE
Add the missing command to clone a package git repo

### DIFF
--- a/doc/rdo-packaging.txt
+++ b/doc/rdo-packaging.txt
@@ -266,8 +266,8 @@ create a `git commit` with an appropriate comment, add a `git remote`
 pointing to gerrit and then submit your patch
 
 [source,bash]
+$> git clone -o gerrit https://review.gerrithub.io/openstack-packages/<package-name>
 $> git commit -p
-$> git remote add gerrit ssh://<username>@review.gerrithub.io:29418/openstack-packages/<package-name>
 $> git review rpm-master
 
 Browsing gerrit for reviews


### PR DESCRIPTION
"Submitting changes to gerrit" section was missing the 'Clone the
package git repository' bit, add it.

Also, remove the explicit step of adding a remote, since we've used '-o'
option to `git clone` which takes care of using specified remote name to
keep track of upstream.