### PR TITLE
Use packages instead of pip for master packaging dependencies

### DIFF
--- a/doc/rdo-packaging.txt
+++ b/doc/rdo-packaging.txt
@@ -222,7 +222,7 @@ In order to build an `RPM` with the master packaging you'll need to install
 Install dependencies
 ~~~~~~~~~~~~~~~~~~~~
 [source,bash]
-$> curl https://copr.fedoraproject.org/coprs/jruzicka/rdopkg/repo/fedora-22/jruzicka-rdopkg-fedora-22.repo -o /etc/yum.repos.d/jruzicka-rdopkg-fedora.repo
+$> sudo curl https://copr.fedoraproject.org/coprs/jruzicka/rdopkg/repo/fedora-22/jruzicka-rdopkg-fedora-22.repo -o /etc/yum.repos.d/jruzicka-rdopkg-fedora.repo
 $> sudo yum install docker-io git createrepo python-virtualenv selinux-policy rdopkg python-oslo-config python-babel python-prettytable python-sh python-sqlalchemy
 $> git clone https://github.com/openstack-packages/delorean.git
 $> cd delorean

--- a/doc/rdo-packaging.txt
+++ b/doc/rdo-packaging.txt
@@ -222,18 +222,17 @@ In order to build an `RPM` with the master packaging you'll need to install
 Install dependencies
 ~~~~~~~~~~~~~~~~~~~~
 [source,bash]
+$> curl https://copr.fedoraproject.org/coprs/jruzicka/rdopkg/repo/fedora-22/jruzicka-rdopkg-fedora-22.repo -o /etc/yum.repos.d/jruzicka-rdopkg-fedora.repo
+$> sudo yum install docker-io git createrepo python-virtualenv selinux-policy rdopkg python-oslo-config python-babel python-prettytable python-sh python-sqlalchemy
 $> git clone https://github.com/openstack-packages/delorean.git
 $> cd delorean
-$> yum install docker-io git createrepo python-virtualenv git-hg selinux-policy
-# For Fedora 21, create a new group `docker`
 $> sudo groupadd docker
 $> sudo usermod -a -G docker $USER; newgrp docker
 $> chcon -t docker_exec_t scripts/*
-$> virtualenv ../delorean-venv
+$> virtualenv --system-site-packages ../delorean-venv
 $> . ../delorean-venv/bin/activate
-$> pip install -r requirements.txt
 $> python setup.py develop
-$> systemctl start docker
+$> sudo systemctl start docker
 
 Prepare a docker "builder" image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Install git before git is used
- Install requirements as packages instead of pip (requirements.txt)
- Prepend sudo where necessary

Thanks go to apevec for sharing his knowledge.